### PR TITLE
Virtual threads APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ This may reduce the utility of some observability tools which interact with gene
 however JVM-based tools like jstack and logging frameworks continue to use the java thread name
 as expected.
 
+### VirtualThreads
+
+The [`ThreadNames`](nylon-threads/src/main/java/com/palantir/nylon/threads/VirtualThreads.java)
+utility allows virtual threads to be safely used from libraries which target older jdk bytecode
+when run using a jdk-21+ runtime.
+
+VirtualThreads provides a static utility method to detect virtual threads:
+```java
+boolean virtual = VirtualThreads.isVirtual(Thread.currentThread())
+```
+
+As well as an API shim over `Thread.ofVirtual()`:
+```java
+VirtualThreadSupport support = VirtualThreads.get().orElseThrow();
+ExecutorService executor = support.newThreadPerTaskExecutor(support.ofVirtual().factory());
+```
 
 Gradle Tasks
 ------------

--- a/build.gradle
+++ b/build.gradle
@@ -50,5 +50,5 @@ subprojects {
 
 javaVersions {
     libraryTarget = 11
-    runtime = 17
+    runtime = 21
 }

--- a/changelog/@unreleased/pr-211.v2.yml
+++ b/changelog/@unreleased/pr-211.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Virtual threads APIs
+  links:
+  - https://github.com/palantir/nylon-threads/pull/211

--- a/nylon-threads/src/main/java/com/palantir/nylon/threads/VirtualThreads.java
+++ b/nylon-threads/src/main/java/com/palantir/nylon/threads/VirtualThreads.java
@@ -16,6 +16,7 @@
 
 package com.palantir.nylon.threads;
 
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
@@ -80,10 +81,19 @@ public final class VirtualThreads {
         /** Alias to the jdk-21 {@code Thread.ofVirtual()} API. */
         VirtualThreadBuilder ofVirtual();
 
+        /**
+         * This type is equivalent to the Thread.Builder.OfVirtual returned by {@code Thread.ofVirtual()} in JDK-21+.
+         * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.Builder.OfVirtual.html">Thread.Builder.OfVirtual</a>
+         */
         interface VirtualThreadBuilder {
-            VirtualThreadBuilder name(String name);
+            /** Sets the threads name. */
+            VirtualThreadBuilder name(@Safe String name);
 
-            VirtualThreadBuilder name(String prefix, long start);
+            /**
+             * Sets the threads name prefix, and the starting value of a counter which is appended to the prefix and
+             * incremented for subsequent threads.
+             */
+            VirtualThreadBuilder name(@Safe String prefix, long start);
 
             VirtualThreadBuilder inheritInheritableThreadLocals(boolean inherit);
 

--- a/nylon-threads/src/main/java/com/palantir/nylon/threads/VirtualThreads.java
+++ b/nylon-threads/src/main/java/com/palantir/nylon/threads/VirtualThreads.java
@@ -170,10 +170,11 @@ public final class VirtualThreads {
         }
 
         @Override
-        @SuppressWarnings({"SafeLoggingPropagation", "IllegalSafeLoggingArgument"})
         public VirtualThreadBuilder ofVirtual() {
             try {
-                return new ReflectiveVirtualThreadBuilder(threadOfVirtual.invoke());
+                // This could use the stricter '.invoke()' method, however
+                // error-prone dataflow fails with "IndexOutOfBoundsException: -1"
+                return new ReflectiveVirtualThreadBuilder(threadOfVirtual.invokeWithArguments());
             } catch (RuntimeException | Error e) {
                 throw e;
             } catch (Throwable t) {

--- a/nylon-threads/src/main/java/com/palantir/nylon/threads/VirtualThreads.java
+++ b/nylon-threads/src/main/java/com/palantir/nylon/threads/VirtualThreads.java
@@ -1,0 +1,275 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.nylon.threads;
+
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Utility functionality to allow libraries which compile for earlier JDKs
+ * to take advantage of virtual threads features on sufficiently new runtimes.
+ */
+public final class VirtualThreads {
+    private static final SafeLogger log = SafeLoggerFactory.get(VirtualThreads.class);
+
+    @Nullable
+    private static final VirtualThreadSupport VIRTUAL_THREAD_SUPPORT = maybeInitialize();
+
+    public static boolean isVirtual(Thread thread) {
+        return VIRTUAL_THREAD_SUPPORT != null && VIRTUAL_THREAD_SUPPORT.isVirtual(thread);
+    }
+
+    public static Optional<VirtualThreadSupport> get() {
+        return Optional.ofNullable(VIRTUAL_THREAD_SUPPORT);
+    }
+
+    @Nullable
+    private static VirtualThreadSupport maybeInitialize() {
+        int featureVersion = Runtime.version().feature();
+        if (featureVersion < 21) {
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Virtual threads are not available prior to jdk21",
+                        SafeArg.of("currentVersion", featureVersion));
+            }
+            return null;
+        }
+        try {
+            return new ReflectiveVirtualThreadSupport();
+        } catch (Throwable t) {
+            log.warn("Virtual thread support is not available", t);
+            return null;
+        }
+    }
+
+    private VirtualThreads() {}
+
+    public interface VirtualThreadSupport {
+        /**
+         * Returns {@code true} if {@code thread} is virtual, {@code false} otherwise.
+         * Equivalent to {@code thread.isVirtual()} on jdk-21+.
+         */
+        boolean isVirtual(Thread thread);
+
+        /** Equivalent to {@code Executors.newThreadPerTaskExecutor(threadFactory)} on jdk-21+. */
+        ExecutorService newThreadPerTaskExecutor(ThreadFactory threadFactory);
+
+        /** Alias to the jdk-21 {@code Thread.ofVirtual()} API. */
+        VirtualThreadBuilder ofVirtual();
+
+        interface VirtualThreadBuilder {
+            VirtualThreadBuilder name(String name);
+
+            VirtualThreadBuilder name(String prefix, long start);
+
+            VirtualThreadBuilder inheritInheritableThreadLocals(boolean inherit);
+
+            VirtualThreadBuilder uncaughtExceptionHandler(UncaughtExceptionHandler ueh);
+
+            Thread unstarted(Runnable task);
+
+            Thread start(Runnable task);
+
+            ThreadFactory factory();
+        }
+    }
+
+    private static final class ReflectiveVirtualThreadSupport implements VirtualThreadSupport {
+
+        private static final MethodType THREAD_IS_VIRTUAL_TYPE = MethodType.methodType(boolean.class);
+
+        private final MethodHandle threadIsVirtual;
+        private final MethodHandle threadOfVirtual;
+        private final MethodHandle ofVirtualFactory;
+        private final MethodHandle ofVirtualNameString;
+        private final MethodHandle ofVirtualNameStringLong;
+        private final MethodHandle ofVirtualInheritInheritableThreadLocals;
+        private final MethodHandle ofVirtualUncaughtExceptionHandler;
+        private final MethodHandle ofVirtualUnstarted;
+        private final MethodHandle ofVirtualStart;
+        private final MethodHandle executorsNewThreadPerTaskExecutor;
+
+        ReflectiveVirtualThreadSupport() throws ReflectiveOperationException {
+            MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+            threadIsVirtual = lookup.findVirtual(Thread.class, "isVirtual", THREAD_IS_VIRTUAL_TYPE);
+            Class<?> ofVirtual = lookup.findClass("java.lang.Thread$Builder$OfVirtual");
+            MethodType threadOfVirtualType = MethodType.methodType(ofVirtual);
+            threadOfVirtual = lookup.findStatic(Thread.class, "ofVirtual", threadOfVirtualType);
+
+            MethodType ofVirtualFactoryType = MethodType.methodType(ThreadFactory.class);
+            ofVirtualFactory = lookup.findVirtual(ofVirtual, "factory", ofVirtualFactoryType);
+
+            MethodType ofVirtualNameStringType = MethodType.methodType(ofVirtual, String.class);
+            ofVirtualNameString = lookup.findVirtual(ofVirtual, "name", ofVirtualNameStringType);
+            MethodType ofVirtualNameStringLongType = MethodType.methodType(ofVirtual, String.class, long.class);
+            ofVirtualNameStringLong = lookup.findVirtual(ofVirtual, "name", ofVirtualNameStringLongType);
+
+            MethodType inheritInheritableThreadLocalsType = MethodType.methodType(ofVirtual, boolean.class);
+            ofVirtualInheritInheritableThreadLocals =
+                    lookup.findVirtual(ofVirtual, "inheritInheritableThreadLocals", inheritInheritableThreadLocalsType);
+
+            MethodType uncaughtExceptionHandlerType = MethodType.methodType(ofVirtual, UncaughtExceptionHandler.class);
+            ofVirtualUncaughtExceptionHandler =
+                    lookup.findVirtual(ofVirtual, "uncaughtExceptionHandler", uncaughtExceptionHandlerType);
+
+            MethodType ofVirtualThreadCreators = MethodType.methodType(Thread.class, Runnable.class);
+            ofVirtualUnstarted = lookup.findVirtual(ofVirtual, "unstarted", ofVirtualThreadCreators);
+            ofVirtualStart = lookup.findVirtual(ofVirtual, "start", ofVirtualThreadCreators);
+
+            MethodType executorsNewThreadPerTaskExecutorType =
+                    MethodType.methodType(ExecutorService.class, ThreadFactory.class);
+            executorsNewThreadPerTaskExecutor = lookup.findStatic(
+                    Executors.class, "newThreadPerTaskExecutor", executorsNewThreadPerTaskExecutorType);
+        }
+
+        @Override
+        public boolean isVirtual(Thread thread) {
+            try {
+                return (boolean) threadIsVirtual.invokeExact(thread);
+            } catch (RuntimeException | Error e) {
+                throw e;
+            } catch (Throwable t) {
+                throw new SafeRuntimeException("failed to invoke 'thread.isVirtual()'", t);
+            }
+        }
+
+        @Override
+        public ExecutorService newThreadPerTaskExecutor(ThreadFactory threadFactory) {
+            try {
+                return (ExecutorService) executorsNewThreadPerTaskExecutor.invoke(threadFactory);
+            } catch (RuntimeException | Error e) {
+                throw e;
+            } catch (Throwable t) {
+                throw new SafeRuntimeException("failed to invoke 'Executors.newThreadPerTaskExecutor'", t);
+            }
+        }
+
+        @Override
+        @SuppressWarnings({"SafeLoggingPropagation", "IllegalSafeLoggingArgument"})
+        public VirtualThreadBuilder ofVirtual() {
+            try {
+                return new ReflectiveVirtualThreadBuilder(threadOfVirtual.invoke());
+            } catch (RuntimeException | Error e) {
+                throw e;
+            } catch (Throwable t) {
+                throw new SafeRuntimeException("failed to invoke 'Thread.ofVirtual()'", t);
+            }
+        }
+
+        @SuppressWarnings("unused")
+        private final class ReflectiveVirtualThreadBuilder implements VirtualThreadBuilder {
+
+            private final Object ofVirtualDelegate;
+
+            ReflectiveVirtualThreadBuilder(Object ofVirtualDelegate) {
+                this.ofVirtualDelegate = ofVirtualDelegate;
+            }
+
+            @Override
+            public VirtualThreadBuilder name(String name) {
+                try {
+                    ofVirtualNameString.invoke(ofVirtualDelegate, name);
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new SafeRuntimeException("failed to invoke 'OfVirtual.name'", t);
+                }
+                return this;
+            }
+
+            @Override
+            public VirtualThreadBuilder name(String prefix, long start) {
+                try {
+                    ofVirtualNameStringLong.invoke(ofVirtualDelegate, prefix, start);
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new SafeRuntimeException("failed to invoke 'OfVirtual.name'", t);
+                }
+                return this;
+            }
+
+            @Override
+            public VirtualThreadBuilder inheritInheritableThreadLocals(boolean inherit) {
+                try {
+                    ofVirtualInheritInheritableThreadLocals.invoke(ofVirtualDelegate, inherit);
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new SafeRuntimeException("failed to invoke 'OfVirtual.inheritInheritableThreadLocals'", t);
+                }
+                return this;
+            }
+
+            @Override
+            public VirtualThreadBuilder uncaughtExceptionHandler(UncaughtExceptionHandler ueh) {
+                try {
+                    ofVirtualUncaughtExceptionHandler.invoke(ofVirtualDelegate, ueh);
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new SafeRuntimeException("failed to invoke 'OfVirtual.uncaughtExceptionHandler'", t);
+                }
+                return this;
+            }
+
+            @Override
+            public Thread unstarted(Runnable task) {
+                try {
+                    return (Thread) ofVirtualUnstarted.invoke(ofVirtualDelegate, task);
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new SafeRuntimeException("failed to invoke 'OfVirtual.unstarted'", t);
+                }
+            }
+
+            @Override
+            public Thread start(Runnable task) {
+                try {
+                    return (Thread) ofVirtualStart.invoke(ofVirtualDelegate, task);
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new SafeRuntimeException("failed to invoke 'OfVirtual.start'", t);
+                }
+            }
+
+            @Override
+            public ThreadFactory factory() {
+                try {
+                    return (ThreadFactory) ofVirtualFactory.invoke(ofVirtualDelegate);
+                } catch (RuntimeException | Error e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new SafeRuntimeException("failed to invoke 'OfVirtual.factory()'", t);
+                }
+            }
+        }
+    }
+}

--- a/nylon-threads/src/test/java/com/palantir/nylon/threads/VirtualThreadsTest.java
+++ b/nylon-threads/src/test/java/com/palantir/nylon/threads/VirtualThreadsTest.java
@@ -1,0 +1,136 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.nylon.threads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.util.concurrent.Runnables;
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.nylon.threads.VirtualThreads.VirtualThreadSupport;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests are primarily meant to exercise each method to ensure calls are properly delegated. We assume
+ * that if data is passed to the underlying APIs, those APIs are implemented correctly.
+ */
+class VirtualThreadsTest {
+
+    @Test
+    public void nonVirtualThread() {
+        assertThat(VirtualThreads.isVirtual(new Thread())).isFalse();
+    }
+
+    @Test
+    public void virtualThreadSupportIsPresent() {
+        assertThat(VirtualThreads.get()).isPresent();
+    }
+
+    @Test
+    public void factory() throws ExecutionException, InterruptedException {
+        VirtualThreadSupport support = VirtualThreads.get().orElseThrow();
+        SettableFuture<Boolean> threadIsVirtual = SettableFuture.create();
+        Thread thread = support.ofVirtual()
+                .factory()
+                .newThread(() -> threadIsVirtual.set(support.isVirtual(Thread.currentThread())));
+        thread.start();
+        assertThat(threadIsVirtual.get()).isTrue();
+    }
+
+    @Test
+    public void name() {
+        String expected = "my-thread";
+        Thread thread =
+                VirtualThreads.get().orElseThrow().ofVirtual().name(expected).unstarted(Runnables.doNothing());
+        assertThat(thread.getName()).isEqualTo(expected);
+    }
+
+    @Test
+    public void namePrefix() {
+        Thread thread = VirtualThreads.get()
+                .orElseThrow()
+                .ofVirtual()
+                .name("my-thread-", 0)
+                .unstarted(Runnables.doNothing());
+        assertThat(thread.getName()).isEqualTo("my-thread-0");
+    }
+
+    @Test
+    public void inheritedThreadLocalsEnabled() throws ExecutionException, InterruptedException {
+        SettableFuture<String> result = SettableFuture.create();
+        InheritableThreadLocal<String> inheritableThreadLocal = new InheritableThreadLocal<>();
+        inheritableThreadLocal.set("parent-thread");
+        VirtualThreads.get()
+                .orElseThrow()
+                .ofVirtual()
+                .inheritInheritableThreadLocals(true)
+                .start(() -> result.set(
+                        Optional.ofNullable(inheritableThreadLocal.get()).orElse("none")));
+        assertThat(result.get()).isEqualTo("parent-thread");
+    }
+
+    @Test
+    public void inheritedThreadLocalsDisabled() throws ExecutionException, InterruptedException {
+        SettableFuture<String> result = SettableFuture.create();
+        InheritableThreadLocal<String> inheritableThreadLocal = new InheritableThreadLocal<>();
+        inheritableThreadLocal.set("parent-thread");
+        VirtualThreads.get()
+                .orElseThrow()
+                .ofVirtual()
+                .inheritInheritableThreadLocals(false)
+                .start(() -> result.set(
+                        Optional.ofNullable(inheritableThreadLocal.get()).orElse("none")));
+        assertThat(result.get()).isEqualTo("none");
+    }
+
+    @Test
+    public void uncaughtExceptionHandler() {
+        UncaughtExceptionHandler customExceptionHandler = (_thread, _throwable) -> {};
+        Thread thread = VirtualThreads.get()
+                .orElseThrow()
+                .ofVirtual()
+                .uncaughtExceptionHandler(customExceptionHandler)
+                .unstarted(Runnables.doNothing());
+        assertThat(thread.getUncaughtExceptionHandler()).isSameAs(customExceptionHandler);
+    }
+
+    @Test
+    public void unstarted() {
+        Thread thread = VirtualThreads.get().orElseThrow().ofVirtual().unstarted(Runnables.doNothing());
+        assertThat(thread.getState()).isEqualTo(Thread.State.NEW);
+    }
+
+    @Test
+    public void start() {
+        Thread thread = VirtualThreads.get().orElseThrow().ofVirtual().start(Runnables.doNothing());
+        Awaitility.waitAtMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> assertThat(thread.getState()).isEqualTo(Thread.State.TERMINATED));
+    }
+
+    @Test
+    void newThreadPerTaskExecutor() {
+        VirtualThreadSupport support = VirtualThreads.get().orElseThrow();
+        ExecutorService exec =
+                support.newThreadPerTaskExecutor(support.ofVirtual().factory());
+        assertThat(exec).isNotNull();
+    }
+}

--- a/nylon-threads/src/test/java/com/palantir/nylon/threads/VirtualThreadsTest.java
+++ b/nylon-threads/src/test/java/com/palantir/nylon/threads/VirtualThreadsTest.java
@@ -36,17 +36,17 @@ import org.junit.jupiter.api.Test;
 class VirtualThreadsTest {
 
     @Test
-    public void nonVirtualThread() {
+    void nonVirtualThread() {
         assertThat(VirtualThreads.isVirtual(new Thread())).isFalse();
     }
 
     @Test
-    public void virtualThreadSupportIsPresent() {
+    void virtualThreadSupportIsPresent() {
         assertThat(VirtualThreads.get()).isPresent();
     }
 
     @Test
-    public void factory() throws ExecutionException, InterruptedException {
+    void factory() throws ExecutionException, InterruptedException {
         VirtualThreadSupport support = VirtualThreads.get().orElseThrow();
         SettableFuture<Boolean> threadIsVirtual = SettableFuture.create();
         Thread thread = support.ofVirtual()
@@ -57,7 +57,7 @@ class VirtualThreadsTest {
     }
 
     @Test
-    public void name() {
+    void name() {
         String expected = "my-thread";
         Thread thread =
                 VirtualThreads.get().orElseThrow().ofVirtual().name(expected).unstarted(Runnables.doNothing());
@@ -65,7 +65,7 @@ class VirtualThreadsTest {
     }
 
     @Test
-    public void namePrefix() {
+    void namePrefix() {
         Thread thread = VirtualThreads.get()
                 .orElseThrow()
                 .ofVirtual()
@@ -75,7 +75,7 @@ class VirtualThreadsTest {
     }
 
     @Test
-    public void inheritedThreadLocalsEnabled() throws ExecutionException, InterruptedException {
+    void inheritedThreadLocalsEnabled() throws ExecutionException, InterruptedException {
         SettableFuture<String> result = SettableFuture.create();
         InheritableThreadLocal<String> inheritableThreadLocal = new InheritableThreadLocal<>();
         inheritableThreadLocal.set("parent-thread");
@@ -89,7 +89,7 @@ class VirtualThreadsTest {
     }
 
     @Test
-    public void inheritedThreadLocalsDisabled() throws ExecutionException, InterruptedException {
+    void inheritedThreadLocalsDisabled() throws ExecutionException, InterruptedException {
         SettableFuture<String> result = SettableFuture.create();
         InheritableThreadLocal<String> inheritableThreadLocal = new InheritableThreadLocal<>();
         inheritableThreadLocal.set("parent-thread");
@@ -103,7 +103,7 @@ class VirtualThreadsTest {
     }
 
     @Test
-    public void uncaughtExceptionHandler() {
+    void uncaughtExceptionHandler() {
         UncaughtExceptionHandler customExceptionHandler = (_thread, _throwable) -> {};
         Thread thread = VirtualThreads.get()
                 .orElseThrow()
@@ -114,13 +114,13 @@ class VirtualThreadsTest {
     }
 
     @Test
-    public void unstarted() {
+    void unstarted() {
         Thread thread = VirtualThreads.get().orElseThrow().ofVirtual().unstarted(Runnables.doNothing());
         assertThat(thread.getState()).isEqualTo(Thread.State.NEW);
     }
 
     @Test
-    public void start() {
+    void start() {
         Thread thread = VirtualThreads.get().orElseThrow().ofVirtual().start(Runnables.doNothing());
         Awaitility.waitAtMost(Duration.ofSeconds(3))
                 .untilAsserted(() -> assertThat(thread.getState()).isEqualTo(Thread.State.TERMINATED));


### PR DESCRIPTION
Adding these to nylon vs a new project/elsewhere:
nylong brings in other dependencies which may not be ideal, however the same argument couldbe made for the `ThreadNames` utilities which are fine in this codebase. Given the overlap with thread-based utilities, and the high likelihood that anything not on jdk-21 at all times will use the nylon executor view, this seemed reasonable.

Naming: I tried to match the jdk-21 apis, which will make code changes simpler once we drop support for older bytecode versions.