### PR TITLE
Add OptionalInt overload for NylonExecutor.builder().maxThreads

### DIFF
--- a/nylon-threads/build.gradle
+++ b/nylon-threads/build.gradle
@@ -8,9 +8,10 @@ dependencies {
     implementation 'org.jboss.threads:jboss-threads'
 
     testImplementation 'com.google.guava:guava'
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'com.palantir.safe-logging:preconditions-assertj'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 
     jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
 }

--- a/nylon-threads/src/main/java/com/palantir/nylon/threads/NylonExecutor.java
+++ b/nylon-threads/src/main/java/com/palantir/nylon/threads/NylonExecutor.java
@@ -17,6 +17,7 @@
 package com.palantir.nylon.threads;
 
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Objects;
 import java.util.OptionalInt;
@@ -54,6 +55,13 @@ public final class NylonExecutor {
          * Executors factory.
          */
         QueueSizeStage maxThreads(int maxThreads);
+
+        /**
+         * Configures the maximum threads allowed for concurrent execution through this executor facade. If no value is
+         * specified, the default is {@link Integer#MAX_VALUE}, matching the standard-library
+         * Executors factory.
+         */
+        QueueSizeStage maxThreads(OptionalInt maxThreads);
     }
 
     public interface QueueSizeStage extends BuildStage {
@@ -103,11 +111,17 @@ public final class NylonExecutor {
 
         @Override
         public QueueSizeStage maxThreads(int value) {
+            return maxThreads(OptionalInt.of(value));
+        }
+
+        @Override
+        public QueueSizeStage maxThreads(OptionalInt value) {
             Preconditions.checkState(maxThreads.isEmpty(), "maxThreads has already been configured");
-            if (value <= 0) {
-                throw new SafeIllegalArgumentException("maxThreads must be positive");
+            if (value.isPresent() && value.getAsInt() <= 0) {
+                throw new SafeIllegalArgumentException(
+                        "maxThreads must be positive", SafeArg.of("maxThreads", value.getAsInt()));
             }
-            maxThreads = OptionalInt.of(value);
+            maxThreads = value;
             return this;
         }
 

--- a/nylon-threads/src/test/java/com/palantir/nylon/threads/NylonExecutorTest.java
+++ b/nylon-threads/src/test/java/com/palantir/nylon/threads/NylonExecutorTest.java
@@ -16,12 +16,16 @@
 
 package com.palantir.nylon.threads;
 
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.logsafe.SafeArg;
 import java.time.Duration;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -218,6 +222,46 @@ class NylonExecutorTest {
             latch.countDown();
             Awaitility.waitAtMost(Duration.ofSeconds(1))
                     .untilAsserted(() -> assertThat(completed).hasValue(2));
+        } finally {
+            assertThat(MoreExecutors.shutdownAndAwaitTermination(delegate, Duration.ofSeconds(1)))
+                    .as("Delegate failed to stop")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void testMaxThreads() {
+        ExecutorService delegate = Executors.newCachedThreadPool();
+        try {
+            assertThatCode(() -> NylonExecutor.builder()
+                            .name("foo")
+                            .executor(delegate)
+                            .maxThreads(OptionalInt.of(1))
+                            .build())
+                    .doesNotThrowAnyException();
+
+            assertThatCode(() -> NylonExecutor.builder()
+                            .name("foo")
+                            .executor(delegate)
+                            .maxThreads(OptionalInt.empty())
+                            .build())
+                    .doesNotThrowAnyException();
+
+            assertThatLoggableExceptionThrownBy(() -> NylonExecutor.builder()
+                            .name("foo")
+                            .executor(delegate)
+                            .maxThreads(-1)
+                            .build())
+                    .hasMessageContaining("maxThreads must be positive")
+                    .hasExactlyArgs(SafeArg.of("maxThreads", -1));
+
+            assertThatLoggableExceptionThrownBy(() -> NylonExecutor.builder()
+                            .name("foo")
+                            .executor(delegate)
+                            .maxThreads(OptionalInt.of(-1))
+                            .build())
+                    .hasMessageContaining("maxThreads must be positive")
+                    .hasExactlyArgs(SafeArg.of("maxThreads", -1));
         } finally {
             assertThat(MoreExecutors.shutdownAndAwaitTermination(delegate, Duration.ofSeconds(1)))
                     .as("Delegate failed to stop")

--- a/versions.lock
+++ b/versions.lock
@@ -8,9 +8,9 @@ com.palantir.safe-logging:logger-slf4j:3.9.0 (1 constraints: 070e6e42)
 
 com.palantir.safe-logging:logger-spi:3.9.0 (2 constraints: 1d1e0c7c)
 
-com.palantir.safe-logging:preconditions:3.9.0 (1 constraints: 0e051536)
+com.palantir.safe-logging:preconditions:3.9.0 (2 constraints: 3e191db6)
 
-com.palantir.safe-logging:safe-logging:3.9.0 (4 constraints: 9a33d562)
+com.palantir.safe-logging:safe-logging:3.9.0 (5 constraints: ca472212)
 
 io.smallrye.common:smallrye-common-annotation:2.12.0 (1 constraints: f00d0344)
 
@@ -50,6 +50,8 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 c
 
 com.google.j2objc:j2objc-annotations:3.0.0 (1 constraints: 150aeab4)
 
+com.palantir.safe-logging:preconditions-assertj:3.9.0 (1 constraints: 0e051536)
+
 net.bytebuddy:byte-buddy:1.15.11 (1 constraints: 7f0bc9ea)
 
 net.sf.jopt-simple:jopt-simple:5.0.4 (1 constraints: be0ad6cc)
@@ -58,7 +60,7 @@ org.apache.commons:commons-math3:3.6.1 (1 constraints: bf0adbcc)
 
 org.apiguardian:apiguardian-api:1.1.2 (6 constraints: 5366ce6e)
 
-org.assertj:assertj-core:3.27.4 (1 constraints: 4205523b)
+org.assertj:assertj-core:3.27.4 (2 constraints: a5195ae0)
 
 org.awaitility:awaitility:4.3.0 (1 constraints: 09050836)
 


### PR DESCRIPTION
## Before this PR
Users who may or may not have a maxThreads value to set have to do an unergonomic intermediate builder to conditionally call the `maxThreads(int)` method:

```
OptionalInt maxThreads = ...

MaxThreadsStage builder =
    NylonExecutor.builder().name(name.get()).executor(sharedExecutor.get());
maxThreads.ifPresent(builder::maxThreads); // <--- here
return builder.uncaughtExceptionHandler(executorFactory.uncaughtExceptionHandler(name))
    .build();
```

## After this PR
==COMMIT_MSG==
Add OptionalInt overload for NylonExecutor.builder().maxThreads
==COMMIT_MSG==

With this change, they can now use a fluent builder all the way through, and express as:

```
OptionalInt maxThreads = ...

return NylonExecutor.builder()
    .name(name.get())
    .executor(sharedExecutor.get())
    .maxThreads(maxThreads) // <--- here
    .uncaughtExceptionHandler(executorFactory.uncaughtExceptionHandler(name))
    .build();
```

## Possible downsides?
- slightly larger API surface