### PR TITLE
Keep old names as part of the RenamingExecutor to debug big cached thread pools

### DIFF
--- a/nylon-threads/src/main/java/com/palantir/nylon/threads/RenamingExecutorService.java
+++ b/nylon-threads/src/main/java/com/palantir/nylon/threads/RenamingExecutorService.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 /** This {@link ExecutorService} wrapper renames threads for the duration of task execution. */
 final class RenamingExecutorService extends AbstractExecutorService {
@@ -76,6 +77,8 @@ final class RenamingExecutorService extends AbstractExecutorService {
     }
 
     final class RenamingRunnable implements Runnable {
+        private static final String ORIGINAL_NAME_DELIMITER = "-was-";
+        private static final Pattern ORIGINAL_NAME_PATTERN = Pattern.compile(ORIGINAL_NAME_DELIMITER);
 
         private final Runnable command;
 
@@ -87,13 +90,16 @@ final class RenamingExecutorService extends AbstractExecutorService {
         public void run() {
             final Thread currentThread = Thread.currentThread();
             final String originalName = currentThread.getName();
-            ThreadNames.setThreadName(currentThread, nameSupplier.get());
+            final String newName = nameSupplier.get();
+            ThreadNames.setThreadName(currentThread, newName);
             try {
                 command.run();
             } catch (Throwable t) {
                 handler.uncaughtException(currentThread, t);
             } finally {
-                ThreadNames.setThreadName(currentThread, originalName);
+                ThreadNames.setThreadName(
+                        currentThread,
+                        ORIGINAL_NAME_PATTERN.split(originalName, 2)[0] + ORIGINAL_NAME_DELIMITER + newName);
             }
         }
     }

--- a/nylon-threads/src/test/java/com/palantir/nylon/threads/NylonExecutorTest.java
+++ b/nylon-threads/src/test/java/com/palantir/nylon/threads/NylonExecutorTest.java
@@ -51,7 +51,7 @@ class NylonExecutorTest {
 
         assertThat(Thread.currentThread().getName())
                 .as("Thread names should not be tainted")
-                .isEqualTo(originalThreadName);
+                .isEqualTo(originalThreadName + "-was-foo-0");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
When using a NylonExecutor to wrap a cached threadpool with a name, when the task would finish, it would rename the thread back to the original name, usually something like `shared-1038`. Many of our cached threadpools actually just share one big shared threadpool. When looking at JFRs or jstacks, it's common to see hundreds of `shared-18034` threads which doesn't provide much info on what task caused the cached threadpool to accumulate threads after the task has finished. This is especially a problem if there is a large number of short-lived but concurrent tasks which cause the threadpool to expand, but doesn't leave a trace of what the task that caused the threadpool to expand so large.

## After this PR
Now, threads will be renamed to `shared-130483-was-taskname` after the task has finished for observability and debugging. We limit to at most one `-was-` suffix to avoid accumulating more and more old task names in the thread names.

## Possible downsides?
I don't think there are any. The regex split is precompiled and should be fast

