### PR TITLE
Use VarHandle to set thread name

### DIFF
--- a/nylon-threads/build.gradle
+++ b/nylon-threads/build.gradle
@@ -14,3 +14,9 @@ dependencies {
 
     jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
 }
+
+moduleJvmArgs {
+    opens = [
+        'java.base/java.lang',
+    ]
+}

--- a/nylon-threads/src/main/java/com/palantir/nylon/threads/ThreadNames.java
+++ b/nylon-threads/src/main/java/com/palantir/nylon/threads/ThreadNames.java
@@ -18,50 +18,32 @@ package com.palantir.nylon.threads;
 
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import java.lang.reflect.Field;
-import java.security.PrivilegedAction;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 
 /** Utility functionality to rename {@link Thread threads} as efficiently as possible. */
-@SuppressWarnings({"UnnecessarilyQualified", "deprecation", "removal"}) // Internal classes should not be imported
 public final class ThreadNames {
 
-    private static final sun.misc.Unsafe unsafe = initUnsafe();
-
-    private static final long threadNameOffset;
-
-    static {
-        try {
-            threadNameOffset = unsafe.objectFieldOffset(Thread.class.getDeclaredField("name"));
-        } catch (NoSuchFieldException e) {
-            throw new SafeIllegalStateException("Failed to find the Thread.name field", e);
-        }
-    }
+    private static final VarHandle THREAD_NAME = getThreadNameVarHandle();
 
     /**
      * Sets the name of a java thread without native overhead to rename the OS thread.
      * Note that unlike {@link Thread#setName(String)} this implementation may not
      * synchronize on the {@code thread} object.
-     *
-     * @see <a href="https://github.com/palantir/atlasdb/pull/5796">atlasdb#5796</a>
      */
     public static void setThreadName(Thread thread, String name) {
         Preconditions.checkNotNull(thread, "Thread is required");
         Preconditions.checkNotNull(name, "Thread name is required");
-        unsafe.putObjectVolatile(thread, threadNameOffset, name);
+        THREAD_NAME.set(thread, name);
     }
 
-    // prevent avoidable failures in spark/etc where security manager is used
-    @SuppressWarnings("removal")
-    private static sun.misc.Unsafe initUnsafe() {
-        return java.security.AccessController.doPrivileged((PrivilegedAction<sun.misc.Unsafe>) () -> {
-            try {
-                Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
-                field.setAccessible(true);
-                return (sun.misc.Unsafe) field.get(null);
-            } catch (ReflectiveOperationException e) {
-                throw new SafeIllegalStateException("Failed to load Unsafe", e);
-            }
-        });
+    private static VarHandle getThreadNameVarHandle() {
+        try {
+            return MethodHandles.privateLookupIn(Thread.class, MethodHandles.lookup())
+                    .findVarHandle(Thread.class, "name", String.class);
+        } catch (ReflectiveOperationException e) {
+            throw new SafeIllegalStateException("Failed to load thread name var handle", e);
+        }
     }
 
     private ThreadNames() {}

--- a/nylon-threads/src/main/java/com/palantir/nylon/threads/ThreadNames.java
+++ b/nylon-threads/src/main/java/com/palantir/nylon/threads/ThreadNames.java
@@ -34,7 +34,7 @@ public final class ThreadNames {
     public static void setThreadName(Thread thread, String name) {
         Preconditions.checkNotNull(thread, "Thread is required");
         Preconditions.checkNotNull(name, "Thread name is required");
-        THREAD_NAME.set(thread, name);
+        THREAD_NAME.setVolatile(thread, name);
     }
 
     private static VarHandle getThreadNameVarHandle() {


### PR DESCRIPTION
## Before this PR

`ThreadNames` uses `Unsafe.objectFieldOffset` to set the thread name. `Unsafe.objectFieldOffset` has been deprecated for removal in Java 23 ([JEP 471](https://openjdk.org/jeps/471)) and usage in Java 24 emits warning logs ([JEP 498](https://openjdk.org/jeps/498)).

## After this PR

`ThreadNames` uses a `VarHandle` to set the thread name.

This requires `--add-opens java.base/java.lang`, which we set using `baseline-module-jvm-args` so it will get picked up by all consumers.

## Possible downsides?

- Are there ways this would fail?
- Is the `AccessController` stuff still relevant?
